### PR TITLE
fix COPRS/reference-system-software#31 

### DIFF
--- a/platform/roles/image/defaults/main.yaml
+++ b/platform/roles/image/defaults/main.yaml
@@ -1,4 +1,4 @@
 qcow2_name: packer-ubuntu-dev
 iso_url: "https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img"
-iso_checksum: "52f31217947783c7a6597dbc572168797882d642801db7b1725eb8cb5fd14437"
+iso_checksum: "file:https://cloud-images.ubuntu.com/focal/current/SHA256SUMS"
 containerd_version: 1.4.9-1


### PR DESCRIPTION
The focal-ubuntu image used during the image creation process is a daily build. As such, its checksums changes often.

This commit changes the checksum from a variable to a link following the image daily builds.