### PR TITLE
fix COPRS/reference-system-software#32

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ cp -rfp inventory/sample inventory/mycluster
 
 # Review and change paramters under ``inventory/mycluster/group_vars`` or ``inventory/mycluster/host_vars``
 cat inventory/mycluster/host_vars/localhost/cluster.yaml
+cat inventory/mycluster/host_vars/localhost/image.yaml
 cat inventory/mycluster/group_vars/all/kubespray.yaml
 cat inventory/mycluster/group_vars/bastion/apps.yaml
 

--- a/platform/inventory/sample/host_vars/localhost/image.yaml
+++ b/platform/inventory/sample/host_vars/localhost/image.yaml
@@ -1,2 +1,3 @@
 # Image creation
+packer_accelerator: kvm
 image_name: csc-rs-ubuntu

--- a/platform/inventory/sample/host_vars/localhost/image.yaml
+++ b/platform/inventory/sample/host_vars/localhost/image.yaml
@@ -1,3 +1,6 @@
-# Image creation
+# Accelerator to use for the packer image building.
+# Change to none if you are on a virtual machine
 packer_accelerator: kvm
+
+# Name of the uploaded image on the tenant
 image_name: csc-rs-ubuntu

--- a/platform/roles/image/templates/base_image.j2
+++ b/platform/roles/image/templates/base_image.j2
@@ -38,13 +38,13 @@
             "output_directory": "{{ playbook_dir }}/../roles/image/files/output/image/",
             {%- raw %}
             "disk_size": "{{user `disk_size`}}",
+            {% endraw -%}
             "disk_compression": true,
             "disk_interface": "virtio",
             "net_device": "virtio-net",
-            "accelerator": "kvm",
+            "accelerator": "{{ packer_accelerator | default("none", true) }}",
             "disk_image": true,
             "shutdown_command": "rm -f /home/safescale/*.txt && rm -f /home/safescale/.ssh/authorized_keys && sudo rm -f /root/.ssh/authorized_keys && sudo -S shutdown -P now"
-            {% endraw -%}
         }
     ],
     "provisioners": [


### PR DESCRIPTION
Packer uses Qemu to build the image later uploaded on the tenant and then used on the cluster nodes.
    
To accelerate the build, Qemu can use kvm. However, kvm is not available on all machines, especially on virtual hardware. This
branch adds the option not to use kvm for the image building.