### PR TITLE
feat[deployment]: Update to latest safescale

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## _Bastion_ requirements
 
-- Safescale : **>= v21.05.0-rc3** (https://github.com/CS-SI/SafeScale)
+- Safescale : **>= v21.11.0** (https://github.com/CS-SI/SafeScale)
 - openstacksdk : **>= v0.12.0** (https://pypi.org/project/openstacksdk/)
 - qemu-system : **>= v4.2.1** (https://packages.ubuntu.com/focal/qemu-kvm / https://packages.ubuntu.com/focal/qemu-system-x86)
 - Packer : **>= v1.7.8** (https://github.com/hashicorp/packer)

--- a/doc/how-to/Rook Ceph.md
+++ b/doc/how-to/Rook Ceph.md
@@ -10,10 +10,10 @@ safescale volume create --size VOLUME_SIZE --speed DISK_TYPE VOLUME_NAME
 
 ### Attach the newly created volume to an existing machine of the cluster
 
-*The volume must be attached without being formatted for Ceph to detect it. You can do this on safescale by adding the option **--do-not-format.***
+*The volume must be attached without being formatted nor mounted for Ceph to detect it. You can do this on safescale by adding the options **--do-not-format** and **--do-not-mount***. 
 
 ```Bash
-safescale volume attach --do-no-format VOLUME_NAME MACHINE_NAME
+safescale volume attach --do-not-format --do-not-mount VOLUME_NAME MACHINE_NAME
 ```
 
 ### Update Ceph to integrate the volume into the Ceph pool

--- a/roles/safescale-cluster/tasks/volumes-create.yaml
+++ b/roles/safescale-cluster/tasks/volumes-create.yaml
@@ -20,7 +20,7 @@
   ignore_errors: yes
 
 - name: Attach the volumes
-  shell: "{{ safescale_path }} volume attach --do-not-format {{ item.0 }}-{{ volume.type }}-{{ item.1 }} {{ item.0 }} "
+  shell: "{{ safescale_path }} volume attach --do-not-format --do-not-mount {{ item.0 }}-{{ volume.type }}-{{ item.1 }} {{ item.0 }} "
   loop: "{{ nodes | product(range(1, volume.count+1)) | list }}"
   async: 30
   poll: 0


### PR DESCRIPTION
This PR makes use of the latest Safescale release, which includes the **--do-not-mount** option used in the creation of the platform's distributed filesystem.