### PR TITLE
fix[deployment]: Remove useless annotation in namespaces

### DIFF
--- a/roles/rs-defaults/templates/ns.yaml.j2
+++ b/roles/rs-defaults/templates/ns.yaml.j2
@@ -6,5 +6,4 @@ metadata:
     name: {{ ns.name }}
     annotations:
       linkerd.io/inject: enabled
-      scheduler.alpha.kubernetes.io/node-selector: {{ ns.nodeSelectorAnnotation }}
 {% endfor %}


### PR DESCRIPTION
This PR fixes a merge issue that left a useless namespace annotation in the platform deployment.