### PR TITLE
Feat: reuse credentials between deployments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 logs
-.ssh
 artifacts
 tenants.*
 ssh-main-gateway.*

--- a/apps/elasticsearch-processing/backup-config/s3-repository.json
+++ b/apps/elasticsearch-processing/backup-config/s3-repository.json
@@ -2,6 +2,6 @@
     "type": "s3",
     "settings": {
       "client": "default",
-      "bucket": "{{ lookup('vars', app_name).backup.s3.bucket }}"
+      "bucket": "{{ elasticsearch_processing.backup.s3.bucket }}"
     }
   }

--- a/apps/elasticsearch-processing/elasticsearch.yaml
+++ b/apps/elasticsearch-processing/elasticsearch.yaml
@@ -70,8 +70,8 @@ spec:
           username: anonymous
           roles: superuser
           authz_exception: false
-        s3.client.default.endpoint: "{{ lookup('vars', app_name).backup.s3.endpoint }}"
-        s3.client.default.region: "{{ lookup('vars', app_name).backup.s3.region }}"
+        s3.client.default.endpoint: "{{ elasticsearch_processing.backup.s3.endpoint }}"
+        s3.client.default.region: "{{ elasticsearch_processing.backup.s3.region }}"
       volumeClaimTemplates:
         - metadata:
             name: elasticsearch-data # Do not change this name unless you set up a volume mount for the data path.

--- a/apps/elasticsearch-processing/filerealm-secret.yaml
+++ b/apps/elasticsearch-processing/filerealm-secret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ app_name }}-filerealm-secret
 stringData:
   users: |-
-    operator:{{ lookup('vars', app_name).operator_password_hash }}
+    operator:{{ elasticsearch_processing.operator_password_hash }}
   users_roles: |-
     monitoring_user:operator
     reporting_user:operator

--- a/apps/elasticsearch-processing/kustomization.yaml
+++ b/apps/elasticsearch-processing/kustomization.yaml
@@ -18,5 +18,5 @@ configMapGenerator:
 secretGenerator:
   - name: {{ app_name }}-s3-credentials
     literals:
-      - S3_ACCESS_KEY={{ lookup('vars', app_name).backup.s3.access_key }}
-      - S3_SECRET_KEY={{ lookup('vars', app_name).backup.s3.secret_key }}
+      - S3_ACCESS_KEY={{ elasticsearch_processing.backup.s3.access_key }}
+      - S3_SECRET_KEY={{ elasticsearch_processing.backup.s3.secret_key }}

--- a/apps/elasticsearch-security/backup-config/s3-repository.json
+++ b/apps/elasticsearch-security/backup-config/s3-repository.json
@@ -2,6 +2,6 @@
     "type": "s3",
     "settings": {
       "client": "default",
-      "bucket": "{{ lookup('vars', app_name).backup.s3.bucket }}"
+      "bucket": "{{ elasticsearch_security.backup.s3.bucket }}"
     }
   }

--- a/apps/elasticsearch-security/elasticsearch.yaml
+++ b/apps/elasticsearch-security/elasticsearch.yaml
@@ -70,8 +70,8 @@ spec:
           username: anonymous
           roles: superuser
           authz_exception: false
-        s3.client.default.endpoint: "{{ lookup('vars', app_name).backup.s3.endpoint }}"
-        s3.client.default.region: "{{ lookup('vars', app_name).backup.s3.region }}"
+        s3.client.default.endpoint: "{{ elasticsearch_security.backup.s3.endpoint }}"
+        s3.client.default.region: "{{ elasticsearch_security.backup.s3.region }}"
       volumeClaimTemplates:
         - metadata:
             name: elasticsearch-data # Do not change this name unless you set up a volume mount for the data path.

--- a/apps/elasticsearch-security/filerealm-secret.yaml
+++ b/apps/elasticsearch-security/filerealm-secret.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ app_name }}-filerealm-secret
 stringData:
   users: |-
-    operator:{{ lookup('vars', app_name).operator_password_hash }}
+    operator:{{ elasticsearch_security.operator_password_hash }}
   users_roles: |-
     monitoring_user:operator
     reporting_user:operator

--- a/apps/elasticsearch-security/kustomization.yaml
+++ b/apps/elasticsearch-security/kustomization.yaml
@@ -18,5 +18,5 @@ configMapGenerator:
 secretGenerator:
   - name: {{ app_name }}-s3-credentials
     literals:
-      - S3_ACCESS_KEY={{ lookup('vars', app_name).backup.s3.access_key }}
-      - S3_SECRET_KEY={{ lookup('vars', app_name).backup.s3.secret_key }}
+      - S3_ACCESS_KEY={{ elasticsearch_security.backup.s3.access_key }}
+      - S3_SECRET_KEY={{ elasticsearch_security.backup.s3.secret_key }}

--- a/delete.yaml
+++ b/delete.yaml
@@ -52,6 +52,5 @@
             path: "{{ item }}"
           loop:
             - "{{ playbook_dir }}/ssh-main-gateway.conf"
-            - "{{ playbook_dir }}/.ssh"
             - "{{ inventory_dir }}/artifacts"
       tags: [ 'never', 'cleanup_generated' ]

--- a/inventory/sample/group_vars/gateway/app_vars.yaml
+++ b/inventory/sample/group_vars/gateway/app_vars.yaml
@@ -57,7 +57,7 @@ thanos:
 grafana:
   oidc_client_secret: "{{ lookup('password', '/dev/null length=60 chars=ascii_letters') }}"
 
-elasticsearch-security:
+elasticsearch_security:
   operator_password_hash: "{{ lookup('password', '/dev/null length=60 chars=ascii_letters') }}"
   kibana_oidc_client_secret: "{{ lookup('password', '/dev/null length=60 chars=ascii_letters') }}"
   backup:
@@ -68,7 +68,7 @@ elasticsearch-security:
       access_key: "{{ common.s3.access_key }}"
       secret_key: "{{ common.s3.secret_key }}"
 
-elasticsearch-processing:
+elasticsearch_processing:
   operator_password_hash: "{{ lookup('password', '/dev/null length=60 chars=ascii_letters') }}"
   kibana_oidc_client_secret: "{{ lookup('password', '/dev/null length=60 chars=ascii_letters') }}"
   backup:

--- a/roles/app-installer/tasks/main.yaml
+++ b/roles/app-installer/tasks/main.yaml
@@ -1,3 +1,28 @@
+- name: Generate or reuse app_vars
+  block:
+    - name: Setting some facts
+      set_fact:
+        generated_app_vars_path: "{{ inventory_dir }}/artifacts/generated_app_vars.yaml"
+        app_vars_path: "{{ inventory_dir }}/group_vars/gateway/app_vars.yaml"
+
+    - name: Check whether generated_app_vars.yaml file exists
+      stat:
+        path: "{{ generated_app_vars_path }}"
+      delegate_to: localhost
+      register: generated_app_vars
+
+    - name: Generate app_vars
+      template:
+        src: "{{ app_vars_path }}"
+        dest: "{{ generated_app_vars_path }}"
+        mode: 0600
+      delegate_to: localhost
+      when: not generated_app_vars.stat.exists
+
+    - name: Load previously generated app_vars
+      include_vars: "{{ generated_app_vars_path }}"
+      delegate_to: localhost
+
 - name: Browse each package
   include_tasks: install_package.yaml
   vars:

--- a/roles/rs-defaults/defaults/main.yaml
+++ b/roles/rs-defaults/defaults/main.yaml
@@ -3,3 +3,7 @@ k8s_namespaces:
   - name: processing
   - name: security
   - name: infra
+  - name: rook-ceph
+  - name: database
+  - name: networking
+  - name: iam

--- a/roles/safescale-cluster/tasks/hosts-update.yaml
+++ b/roles/safescale-cluster/tasks/hosts-update.yaml
@@ -12,7 +12,7 @@
 - name: Setting some facts
   set_fact:
     main_gateway_ip: "{{ main_gateway_ip.stdout }}"
-    ssh_key_path: "{{ playbook_dir }}/.ssh"
+    ssh_key_path: "{{ inventory_dir }}/artifacts/.ssh"
 
 - name: Creating the .ssh folder for the cluster ssh keys
   file:

--- a/rs-setup.yaml
+++ b/rs-setup.yaml
@@ -85,7 +85,7 @@
   vars_files: 
     - "collections/kubespray/roles/download/defaults/main.yml"
     - "collections/kubespray/roles/kubespray-defaults/defaults/main.yaml"
-  pre_ tasks:
+  pre_tasks:
     - name: install pip modules for ansible kubernetes.core
       pip: 
         name: "{{ item }}"
@@ -93,6 +93,7 @@
         - pyyaml==5.3.1
         - openshift==0.12.1
         - kubernetes==12.0.1
+        - hvac==0.11.2
   roles:
     - { role: "collections/kubespray/roles/kubernetes-apps/helm" }
     - { role: "kustomize" }


### PR DESCRIPTION
This PR implements a automatic generation of a file containing the credentials generated or retrieved before deploying the packages. It allows the operator to reuse the same variables and not break the apps configurations in case of deployment.

Some refactoring of the elasticsearch variables for configuration harmony is included.

Related to https://github.com/COPRS/rs-issues/issues/234