### PR TITLE
Fix: #287

### DIFF
--- a/apps/20-prometheus-stack/values.yaml
+++ b/apps/20-prometheus-stack/values.yaml
@@ -1,5 +1,5 @@
 defaultRules:
-  create: false
+  create: true
 
 alertmanager:
   serviceMonitor:


### PR DESCRIPTION
This PR enables optional prometheus rules in order to generate metrics that are used by common platform monitoring dashboards.
Closes https://github.com/COPRS/rs-issues/issues/287