### PR TITLE
feat: Integrate private artifactory into scdf

### DIFF
--- a/apps/spring-cloud-dataflow/kustomization.yaml
+++ b/apps/spring-cloud-dataflow/kustomization.yaml
@@ -7,9 +7,22 @@ helmCharts:
 - name: spring-cloud-dataflow
   releaseName: "{{ app_name }}"
   repo: https://charts.bitnami.com/bitnami
-  version: 4.1.5
+  version: 7.0.1
   valuesFile: values.yaml
   namespace: processing
 
 resources:
   - apisixroute.yaml
+
+secretGenerator:
+  - name: spring-cloud-dataflow-registry-dockersecret
+    files:
+      - .dockerconfigjson=registry-dockersecret.json
+    options:
+      disableNameSuffixHash: true
+    type: kubernetes.io/dockerconfigjson
+  - name: spring-cloud-dataflow-registry-config
+    files:
+      - SPRING_APPLICATION_JSON=registry-config.json
+    options:
+      disableNameSuffixHash: true

--- a/apps/spring-cloud-dataflow/registry-config.json
+++ b/apps/spring-cloud-dataflow/registry-config.json
@@ -1,0 +1,18 @@
+{
+  "spring": {
+    "cloud": {
+      "dataflow": {
+        "container": {
+          "registry-configurations": {
+            "artifactory": {
+              "registry-host": "{{ scdf.registry.url.split('//')[1] }}",
+              "authorization-type": "basicauth",
+              "user": "{{ scdf.registry.username }}",
+              "secret": "{{ scdf.registry.password }}"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apps/spring-cloud-dataflow/registry-dockersecret.json
+++ b/apps/spring-cloud-dataflow/registry-dockersecret.json
@@ -1,0 +1,9 @@
+{
+  "auths": {
+    "{{ scdf.registry.url }}": {
+      "username": "{{ scdf.registry.username }}",
+      "password": "{{ scdf.registry.password }}",
+      "auth": "{{ (scdf.registry.username~':'~scdf.registry.password) | b64encode }}"
+    }
+  }
+}

--- a/apps/spring-cloud-dataflow/values.yaml
+++ b/apps/spring-cloud-dataflow/values.yaml
@@ -3,6 +3,9 @@ global:
 server:
   image:
     tag: 2.9.1-debian-10-r7
+  configuration:
+    defaultSpringApplicationJSON: false
+  extraEnvVarsSecret: spring-cloud-dataflow-registry-config
   composedTaskRunner:
     image:
       tag: 2.9.1-debian-10-r7
@@ -37,6 +40,8 @@ skipper:
     requests:
       cpu: 500m
       memory: 512Mi
+deployer:
+  imagePullSecrets: [spring-cloud-dataflow-registry-dockersecret]
 metrics:
   enabled: true
   image:

--- a/inventory/sample/host_vars/setup/apps/spring-cloud-dataflow.yaml
+++ b/inventory/sample/host_vars/setup/apps/spring-cloud-dataflow.yaml
@@ -2,3 +2,7 @@ scdf:
   database:
     password: "{{ lookup('password', '/dev/null length=60 chars=ascii_letters') }}"
   oidc_client_secret: "{{ lookup('password', '/dev/null length=60 chars=ascii_letters') }}"
+  registry:
+    url: SCDF_REGISTRY_URL
+    username: SCDF_REGISTRY_USERNAME
+    password: SCDF_REGISTRY_PASSWORD # use artifactory "centrally secure password" 


### PR DESCRIPTION
This PR integrates artifactory credentials into the *Spring Cloud Dataflow* deployment, in order to read metadata and download artifacts from a remote private artifactory. (like F2)

Related to https://github.com/COPRS/rs-issues/issues/233