### PR TITLE
feat: update spring cloud dataflow to 2.9.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,8 +386,8 @@ Default configurations:
     - Version: 7.0.1
     - Source: https://github.com/bitnami/charts/tree/master/bitnami/spring-cloud-dataflow
   - Images:
-    - docker.io/bitnami/spring-cloud-dataflow:2.9.1-debian-10-r7
-    - docker.io/bitnami/spring-cloud-skipper:2.8.1-debian-10-r6
+    - docker.io/bitnami/spring-cloud-dataflow:2.9.4-debian-10-r7
+    - docker.io/bitnami/spring-cloud-skipper:2.8.4-debian-10-r6
     - docker.io/bitnami/prometheus-rsocket-proxy:1.3.0-debian-10-r334
 - **Keda**
   - Helm chart:

--- a/apps/spring-cloud-dataflow/values.yaml
+++ b/apps/spring-cloud-dataflow/values.yaml
@@ -2,13 +2,13 @@ global:
   storageClass: ceph-block
 server:
   image:
-    tag: 2.9.1-debian-10-r7
+    tag: 2.9.4-debian-10-r0
   configuration:
     defaultSpringApplicationJSON: false
   extraEnvVarsSecret: spring-cloud-dataflow-registry-config
   composedTaskRunner:
     image:
-      tag: 2.9.1-debian-10-r7
+      tag: 2.9.4-debian-10-r0
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -25,7 +25,7 @@ server:
       memory: 512Mi
 skipper:
   image:
-    tag: 2.8.1-debian-10-r6
+    tag: 2.8.4-debian-10-r0
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/doc/user_manual.md
+++ b/doc/user_manual.md
@@ -6,7 +6,7 @@
 - For Graylog : https://docs.graylog.org/docs
 - For Apisix : https://apisix.apache.org/docs/apisix/getting-started/
 - For Linkerd : https://linkerd.io/2.11/overview/
-- For Spring Cloud Data Flow : https://docs.spring.io/spring-cloud-dataflow/docs/2.9.1/reference/htmlsingle/
+- For Spring Cloud Data Flow : https://docs.spring.io/spring-cloud-dataflow/docs/2.9.4/reference/htmlsingle/
 - For Kibana : https://www.elastic.co/guide/en/kibana/7.15/index.html
 - For Keycloak : https://www.keycloak.org/documentation.html
 - For Keda : https://keda.sh/docs/1.4/concepts/scaling-deployments/


### PR DESCRIPTION
This PR includes an spring cloud dataflow update, for [CVE-2022-22965](https://tanzu.vmware.com/security/cve-2022-22965)