### PR TITLE
fix: clamav tmp dir locked by AppArmor

### DIFF
--- a/roles/security/clamav/files/clamav-clamonacc.service
+++ b/roles/security/clamav/files/clamav-clamonacc.service
@@ -8,7 +8,7 @@ After=clamav-daemon.service syslog.target network.target
 Type=simple
 User=root
 ExecStartPre=/bin/bash -c "while [ ! -S /run/clamav/clamd.ctl ]; do sleep 1; done"
-ExecStart=/usr/sbin/clamonacc --fdpass -F --config-file=/etc/clamav/clamd.conf --log=/var/log/clamav/clamonacc.log --move=/root/quarantine
+ExecStart=/usr/sbin/clamonacc --fdpass -F --config-file=/etc/clamav/clamd.conf --move=/root/quarantine
 
 [Install]
 WantedBy=multi-user.target

--- a/roles/security/clamav/files/clamd.conf
+++ b/roles/security/clamav/files/clamd.conf
@@ -2,7 +2,6 @@
 
 # On access settings
 OnAccessIncludePath /home
-OnAccessIncludePath /tmp
 OnAccessPrevention true
 OnAccessExtraScanning true
 OnAccessMaxFileSize 5M
@@ -21,7 +20,7 @@ LogClean false
 LogVerbose false
 
 # Other settings
-TemporaryDirectory /var/tmp
+TemporaryDirectory /tmp
 ConcurrentDatabaseReload no
 LocalSocket /var/run/clamav/clamd.ctl
 FixStaleSocket true


### PR DESCRIPTION
This PR sets the clamav temporary scanning directory to its default value, because after a node restart AppArmor policies would prevent clamd from scanning anything using a temp directory different than /tmp.