### PR TITLE
fix: correction to rs-addon unzipped path

### DIFF
--- a/roles/rs-addon/tasks/main.yaml
+++ b/roles/rs-addon/tasks/main.yaml
@@ -44,7 +44,7 @@
 
     - name: Get stream definition
       slurp:
-        src: "{{ rs_addon_dir.path }}/{{ rs_addon_name }}/{{ rs_addon_name }}_Executables/stream-definition.properties"
+        src: "{{ rs_addon_dir.path }}/{{ rs_addon_name }}_Executables/stream-definition.properties"
       register: stream_definition_content
 
     - name: Parse stream-definition file
@@ -59,7 +59,7 @@
 
     - name: Get stream properties
       slurp:
-        src: "{{ rs_addon_dir.path }}/{{ rs_addon_name }}/{{ rs_addon_name }}_Executables/stream-parameters.properties"
+        src: "{{ rs_addon_dir.path }}/{{ rs_addon_name }}_Executables/stream-parameters.properties"
       register: stream_properties_content
 
     - name: Parse stream-properties file
@@ -73,11 +73,11 @@
 
     - name: Check if additional_resources folder exists
       stat:
-        path: "{{ rs_addon_dir.path }}/{{ rs_addon_name }}/{{ rs_addon_name }}_Executables/additional_resources"
+        path: "{{ rs_addon_dir.path }}/{{ rs_addon_name }}_Executables/additional_resources"
       register: additional_resources_dir    
 
     - name: Deploy the additional resources into the cluster
-      shell: "kubectl apply -f {{ rs_addon_dir.path }}/{{ rs_addon_name }}/{{ rs_addon_name }}_Executables/additional_resources/"
+      shell: "kubectl apply -f {{ rs_addon_dir.path }}/{{ rs_addon_name }}_Executables/additional_resources/"
       register: deploy_log
       when: additional_resources_dir.stat.exists and additional_resources_dir.stat.isdir
 

--- a/roles/rs-addon/templates/scdf_shell_script.txt
+++ b/roles/rs-addon/templates/scdf_shell_script.txt
@@ -1,5 +1,5 @@
 
-app import --uri file://{{ rs_addon_dir.path }}/{{ rs_addon_name }}/{{ rs_addon_name }}_Executables/stream-application-list.properties
+app import --uri file://{{ rs_addon_dir.path }}/{{ rs_addon_name }}_Executables/stream-application-list.properties
 
 stream create --name {{ stream_name }} --definition {{ stream_definition }}
 


### PR DESCRIPTION
Fix issue COPRS/rs-issues#368

Changes the expected path of the rs-addon files from `{{ rs_addon_dir.path }}/{{rs_addon_name}}/{{ rs_addon_name }}_Executables/additional_resources` to `{{ rs_addon_dir.path }}/{{ rs_addon_name }}_Executables/additional_resources` to follow ICD.