### PR TITLE
fix: correction to rs-addon properties parsing

### DIFF
--- a/roles/rs-addon/tasks/main.yaml
+++ b/roles/rs-addon/tasks/main.yaml
@@ -64,7 +64,7 @@
 
     - name: Parse stream-properties file
       set_fact:
-        stream_properties: "{{ stream_properties_content.content | b64decode | regex_replace('\\n', ',') }}"
+        stream_properties: "{{ stream_properties_content.content | b64decode | regex_replace('#.*\\n','') | regex_replace('\\n\\n', '\\n') | regex_replace('\\n', ',') }}"
 
     - name: Template script to gw
       template:


### PR DESCRIPTION
Fixes issue COPRS/rs-issues#370

Removes commentaries and empty lines in the rs-addon properties file before the properties are given to the scdf shell.