### PR TITLE
fix: add keycloak route for each subdomain

### DIFF
--- a/apps/30-linkerd-viz/apisixroute.yaml
+++ b/apps/30-linkerd-viz/apisixroute.yaml
@@ -29,7 +29,7 @@ spec:
           config:
             client_id: linkerd
             client_secret: {{ linkerd.oidc_client_secret }}
-            discovery: https://iam.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/.well-known/openid-configuration
+            discovery: https://linkerd.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/.well-known/openid-configuration
             scope: openid
             bearer_only: false
             realm: {{ keycloak.realm.name }}

--- a/apps/70-elasticsearch-processing/apisixroute-kibana.yaml
+++ b/apps/70-elasticsearch-processing/apisixroute-kibana.yaml
@@ -29,7 +29,7 @@ spec:
           config:
             client_id: kibana-processing
             client_secret: "{{ elasticsearch_processing.kibana_oidc_client_secret }}"
-            discovery: https://iam.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/.well-known/openid-configuration
+            discovery: https://processing.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/.well-known/openid-configuration
             scope: openid
             bearer_only: false
             realm: {{ keycloak.realm.name }}

--- a/apps/70-elasticsearch-security/apisixroute-kibana.yaml
+++ b/apps/70-elasticsearch-security/apisixroute-kibana.yaml
@@ -29,7 +29,7 @@ spec:
           config:
             client_id: kibana-security
             client_secret: "{{ elasticsearch_security.kibana_oidc_client_secret }}"
-            discovery: https://iam.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/.well-known/openid-configuration
+            discovery: https://security.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/.well-known/openid-configuration
             scope: openid
             bearer_only: false
             realm: {{ keycloak.realm.name }}

--- a/apps/70-thanos/apisixroute.yaml
+++ b/apps/70-thanos/apisixroute.yaml
@@ -25,7 +25,7 @@ spec:
           config:
             client_id: thanos
             client_secret: {{ thanos.oidc_client_secret }}
-            discovery: https://iam.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/.well-known/openid-configuration
+            discovery: https://monitoring.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/.well-known/openid-configuration
             scope: openid
             bearer_only: false
             realm: {{ keycloak.realm.name }}

--- a/apps/80-prometheus-stack/apisixroute.yaml
+++ b/apps/80-prometheus-stack/apisixroute.yaml
@@ -20,7 +20,7 @@ spec:
           config:
             client_id: prometheus
             client_secret: {{ prometheus.oidc_client_secret }}
-            discovery: https://iam.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/.well-known/openid-configuration
+            discovery: https://monitoring.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/.well-known/openid-configuration
             scope: openid
             bearer_only: false
             realm: {{ keycloak.realm.name }}

--- a/apps/apisix/apisixroute.yaml
+++ b/apps/apisix/apisixroute.yaml
@@ -17,7 +17,7 @@ spec:
           config:
             client_id: apisix
             client_secret: {{ apisix.oidc_client_secret }}
-            discovery: https://iam.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/.well-known/openid-configuration
+            discovery: https://apisix.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/.well-known/openid-configuration
             scope: openid
             bearer_only: false
             realm: {{ keycloak.realm.name }}

--- a/apps/grafana/grafana.yaml
+++ b/apps/grafana/grafana.yaml
@@ -18,15 +18,15 @@ spec:
     auth:
       oauth_auto_login: true
       disable_login_form: true
-      signout_redirect_url: https://iam.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/protocol/openid-connect/logout?redirect_uri=https%3A%2F%2Fmonitoring.{{ platform_domain_name }}
+      signout_redirect_url: https://monitoring.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/protocol/openid-connect/logout?redirect_uri=https%3A%2F%2Fmonitoring.{{ platform_domain_name }}
     auth.generic_oauth:
       enabled: true
       allow_sign_up: true
       client_id: grafana
       scopes: profile
-      auth_url: https://iam.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/protocol/openid-connect/auth
-      token_url: https://iam.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/protocol/openid-connect/token
-      api_url: https://iam.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/protocol/openid-connect/userinfo
+      auth_url: https://monitoring.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/protocol/openid-connect/auth
+      token_url: https://monitoring.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/protocol/openid-connect/token
+      api_url: https://monitoring.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/protocol/openid-connect/userinfo
       role_attribute_path: contains(roles[*], 'admin') && 'Admin' || contains(roles[*], 'editor') && 'Editor' || 'Viewer'
       role_attribute_strict: true
     metrics:

--- a/apps/graylog/apisixroute.yaml
+++ b/apps/graylog/apisixroute.yaml
@@ -23,7 +23,7 @@ spec:
           config:
             client_id: graylog
             client_secret: {{ graylog.oidc_client_secret }}
-            discovery: https://iam.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/.well-known/openid-configuration
+            discovery: https://security.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/.well-known/openid-configuration
             scope: openid
             bearer_only: false
             realm: {{ keycloak.realm.name }}

--- a/apps/keycloak/apisixroute.yaml
+++ b/apps/keycloak/apisixroute.yaml
@@ -9,7 +9,13 @@ spec:
         - serviceName: keycloak-http
           servicePort: 80
       match:
-        hosts: [ iam.{{ platform_domain_name }} ]
+        hosts:
+          - apisix.{{ platform_domain_name }}
+          - iam.{{ platform_domain_name }}
+          - linkerd.{{ platform_domain_name }}
+          - monitoring.{{ platform_domain_name }}
+          - processing.{{ platform_domain_name }}
+          - security.{{ platform_domain_name }}
         paths:
           - /auth/admin/{{ keycloak.realm.name }}
           - /auth/admin/{{ keycloak.realm.name }}/*
@@ -17,16 +23,13 @@ spec:
           - /auth/admin/{{ keycloak.realm.name }}/console/*
           - /auth/admin/realms
           - /auth/admin/serverinfo
+          - /auth/realms/{{ keycloak.realm.name }}/.well-known/openid-configuration
           - /auth/realms/{{ keycloak.realm.name }}/account/*
           - /auth/realms/{{ keycloak.realm.name }}/protocol/openid-connect/*
           - /auth/realms/RS/login-actions/*
           - /auth/resources/*
           - /auth/js/*
       plugins:
-        - name: cors
-          enable: true
-          config:
-            allow_origins: "https://apisix.{{ platform_domain_name }},https://linkerd.{{ platform_domain_name }},https://monitoring.{{ platform_domain_name }},https://security.{{ platform_domain_name }},https://processing.{{ platform_domain_name }}"
         - name: serverless-pre-function
           enable: true
           config:
@@ -47,7 +50,12 @@ metadata:
   name: sni-iam
 spec:
   hosts:
+    - apisix.{{ platform_domain_name }}
     - iam.{{ platform_domain_name }}
+    - linkerd.{{ platform_domain_name }}
+    - monitoring.{{ platform_domain_name }}
+    - processing.{{ platform_domain_name }}
+    - security.{{ platform_domain_name }}
   secret:
     name: ingress-tls
     namespace:  networking

--- a/apps/spring-cloud-dataflow/apisixroute.yaml
+++ b/apps/spring-cloud-dataflow/apisixroute.yaml
@@ -22,7 +22,7 @@ spec:
           config:
             client_id: scdf
             client_secret: {{ scdf.oidc_client_secret }}
-            discovery: https://iam.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/.well-known/openid-configuration
+            discovery: https://processing.{{ platform_domain_name }}/auth/realms/{{ keycloak.realm.name }}/.well-known/openid-configuration
             scope: openid
             bearer_only: false
             realm: {{ keycloak.realm.name }}


### PR DESCRIPTION
Fixes COPRS/rs-issues#318:

- Changes the keycloak apisixroutes so that it is exposed on every subdomain
- Changes the OICD discovery path of each app to the keycloak url of the same subdomain