### PR TITLE
fix: change blackbox-exporter chart version

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ Default configurations:
 - **Prometheus blackbox exporter**
   - Helm chart:
     - Repository: https://prometheus-community.github.io/helm-charts
-    - Version: 5.8.1
+    - Version: 5.8.2
     - Source: https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-blackbox-exporter
   - Images:
     - docker.io/prom/blackbox-exporter:v0.20.0

--- a/apps/prometheus-blackbox-exporter/kustomization.yaml
+++ b/apps/prometheus-blackbox-exporter/kustomization.yaml
@@ -7,7 +7,7 @@ helmCharts:
 - name: prometheus-blackbox-exporter
   releaseName: "{{ app_name }}"
   repo: https://prometheus-community.github.io/helm-charts
-  version: 5.8.1
+  version: 5.8.2
   valuesFile: values.yaml
   namespace: monitoring
 


### PR DESCRIPTION
Fix for issue COPRS/rs-issues#440

Changes:
- chart version of prometheus-blackbox-exporter is changed to 5.8.2