### PR TITLE
feat: taints and tolerations improvements

### DIFF
--- a/apps/20-linkerd/values.yaml
+++ b/apps/20-linkerd/values.yaml
@@ -231,7 +231,7 @@ spValidatorResources:
 installNamespace: false
 
 nodeSelector:
-  kubernetes.io/os: linux
+  node-role.kubernetes.io/infra: ""
 
 podAnnotations:
   linkerd.io/inject: disabled

--- a/apps/50-ceph-filesystems/ceph-tools.yaml
+++ b/apps/50-ceph-filesystems/ceph-tools.yaml
@@ -46,11 +46,6 @@ spec:
             - mountPath: /etc/rook
               name: mon-endpoint-volume
       dnsPolicy: ClusterFirstWithHostNet
-      tolerations:
-        - effect: NoExecute
-          key: node.kubernetes.io/unreachable
-          operator: Exists
-          tolerationSeconds: 5
       volumes:
         - configMap:
             items:

--- a/apps/50-ceph-filesystems/cephcluster.yaml
+++ b/apps/50-ceph-filesystems/cephcluster.yaml
@@ -71,6 +71,10 @@ spec:
             - matchExpressions:
                 - key: node-role.kubernetes.io/rook_ceph
                   operator: Exists
+      tolerations:
+        - key: node-role.kubernetes.io/rook_ceph
+          operator: Exists
+          effect: NoSchedule
   priorityClassNames:
     mon: system-node-critical
     osd: system-node-critical

--- a/apps/50-ceph-filesystems/cephsharedfilesystem.yaml
+++ b/apps/50-ceph-filesystems/cephsharedfilesystem.yaml
@@ -31,6 +31,10 @@ spec:
                   values:
                     - rook-ceph-mds
             topologyKey: kubernetes.io/hostname
+      tolerations:
+        - key: node-role.kubernetes.io/rook_ceph
+          operator: Exists
+          effect: NoSchedule
     resources:
      limits:
        cpu: 3

--- a/apps/70-fluent-bit/values.yaml
+++ b/apps/70-fluent-bit/values.yaml
@@ -320,6 +320,4 @@ daemonSetVolumeMounts:
 
 tolerations:
   - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/gateway
+    operator: Exists

--- a/apps/apisix/values.yaml
+++ b/apps/apisix/values.yaml
@@ -23,7 +23,13 @@ apisix:
 
   nodeSelector: {}
   tolerations: []
-  affinity: {}
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+            - key: "node-role.kubernetes.io/infra"
+              operator: Exists
   # If true, it will sets the anti-affinity of the Pod.
   podAntiAffinity:
     enabled: true

--- a/apps/falco-exporter/values.yaml
+++ b/apps/falco-exporter/values.yaml
@@ -28,6 +28,4 @@ resources:
 # Allow falco-exporter to run on Kubernetes 1.6 masters.
 tolerations:
   - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/gateway
+    operator: Exists

--- a/apps/falco/values.yaml
+++ b/apps/falco/values.yaml
@@ -31,6 +31,4 @@ resources:
 # Allow Falco to run on Kubernetes 1.6 masters.
 tolerations:
   - effect: NoSchedule
-    key: node-role.kubernetes.io/master
-  - effect: NoSchedule
-    key: node-role.kubernetes.io/gateway
+    operator: Exists

--- a/inventory/sample/host_vars/setup/safescale.yaml
+++ b/inventory/sample/host_vars/setup/safescale.yaml
@@ -52,6 +52,8 @@ cluster:
       kubespray:
         node_labels:
           node-role.kubernetes.io/rook_ceph: ''
+        node_taints:
+          - node-role.kubernetes.io/rook_ceph:NoSchedule
     - name: processing
       min_size: 0
       max_size: 6

--- a/user_manuals/how-to/Cluster configuration.md
+++ b/user_manuals/how-to/Cluster configuration.md
@@ -80,6 +80,8 @@ cluster:
       kubespray:
         node_labels:
           node-role.kubernetes.io/rook_ceph: ''
+        node_taints:
+          - node-role.kubernetes.io/rook_ceph:NoSchedule
 ```
 
 ## S3 buckets


### PR DESCRIPTION
Improvements:
 - NoSchedule taint on rook_ceph nodes for better isolation
 - Generic tolerations on fluent-bit and flaco daemonset

Fix:
 - add missing affinities on apisix and linkerd pods