### PR TITLE
fix: set scdf stream deployment namespace at playbook launch

### DIFF
--- a/docs/user_manuals/howto/RS Add-on - RS Core.md
+++ b/docs/user_manuals/howto/RS Add-on - RS Core.md
@@ -14,7 +14,8 @@ For example:
 ansible-playbook deploy-rs-addon.yaml \
     -i inventory/mycluster/hosts.yaml \
     -e rs_addon_location=https://artifactory.coprs.esa-copernicus.eu/artifactory/demo-zip/demo-rs-addon.zip \
-    -e stream_name=example-stream-name
+    -e stream_name=STREAM_NAME \
+    -e stream_namespace=NAMESPACE
 ```
 
 ## Use different namespaces in stream deployments
@@ -30,12 +31,8 @@ scdf:
     - ...
 ```
 
-You will then be able to choose the namespace you want the stream to be deployed into by setting the following variable the the stream properties according to the ICD definition:
-```
-[...]
-spring.cloud.dataflow.skipper.platformName=NAMESPACE
-[...]
-```
+You will then be able to choose the namespace you want the stream to be deployed into by using the `-e stream_namespace=NAMESPACE` option on stream deployment.
+
 
 ## Uninstall
 

--- a/roles/rs-addon/templates/scdf_shell_script.sh.j2
+++ b/roles/rs-addon/templates/scdf_shell_script.sh.j2
@@ -10,6 +10,6 @@ app import --uri file://{{ remote_rs_addon_dir.path }}/stream-application-list.p
 {# create stream #}
 stream create --name {{ stream_name | replace ('.', '-') | replace ('_', '-') }}-part{{ loop.index }} --definition "{{ stream_definition | trim }}"
 {# deploy stream #}
-stream deploy --name {{ stream_name | replace ('.', '-') | replace ('_', '-') }}-part{{ loop.index }} --properties "{{ stream_properties | join(',') }}"
+stream deploy --platformName {{ stream_namespace | default('default') }} --name {{ stream_name | replace ('.', '-') | replace ('_', '-') }}-part{{ loop.index }} --properties "{{ stream_properties | join(',') }}"
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
This PR allows setting up the namespace used for stream deployment at the ansible playbook launch.

This improves the reliability and flexibility of the stream namespaces.