### PR TITLE
feat: update fluent-bit to 2.0.6

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -129,12 +129,12 @@ Below are all the Commercial off-the-shelf (COTS) used and their respective lice
 
 - Fluent-bit 
   - Helm chart:
-    - Version: 0.19.6
+    - Version: 0.21.4
     - Licence: [Apache License 2.0](https://github.com/fluent/helm-charts/blob/fluent-bit-0.19.6/LICENSE)
     - Source: https://github.com/fluent/helm-charts/tree/fluent-bit-0.19.6/charts/fluent-bit
   - Container image(s)
-    - docker.io/fluent/fluent-bit:1.9.3
-      - License: [Apache License 2.0](https://github.com/fluent/fluent-bit/blob/v1.9.3/LICENSE)
+    - artifactory.coprs.esa-copernicus.eu/rs-docker/fluent-bit-plugin-loki:2.0.6
+      - License: [Apache License 2.0](https://github.com/fluent/fluent-bit/blob/v2.0.6/LICENSE)
 
 - MongoDB
   - Helm chart:

--- a/apps/70-fluent-bit/kustomization.yaml
+++ b/apps/70-fluent-bit/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: logging
 helmCharts:
 - name: fluent-bit
   repo: https://fluent.github.io/helm-charts
-  version: 0.19.6
+  version: 0.21.4
   valuesFile: values.yaml
   releaseName: "{{ app_name }}"
 

--- a/apps/70-fluent-bit/values.yaml
+++ b/apps/70-fluent-bit/values.yaml
@@ -2,7 +2,7 @@ kind: DaemonSet
 
 image:
   repository: artifactory.coprs.esa-copernicus.eu/rs-docker/fluent-bit-plugin-loki
-  tag: 1.9.3
+  tag: 2.0.6
 
 logLevel: warn
 
@@ -66,7 +66,7 @@ config:
       Max_Entries       500
       Read_From_Tail    Off
       DB                /var/log/fluentbit_systemd.db
-      DB_Sync           Normal
+      DB.Sync           Normal
       Strip_Underscores On
       Lowercase         On
     [INPUT]


### PR DESCRIPTION
This PR updates fluent-bit chart and docker image to the latest versions:
 
Should fix https://github.com/coprs/rs-issues/issues/607